### PR TITLE
合并浙江传媒学院，麦锋源，1910130021

### DIFF
--- a/list.csv
+++ b/list.csv
@@ -1,3 +1,4 @@
 学校,所在学院,URL
 中山大学南方学院,文学与传媒学院,http：//wcy.nfu.edu.cn/a/xueyuangaikuang/zhuanyeshezhi/wangluoyuxinmeitix/
 广州大学,新闻与传播学院,http://xw.gzhu.edu.cn/
+浙江传媒学院,文化创意与管理学院,http://www.cuz.edu.cn/


### PR DESCRIPTION
合并浙江传媒学院，文化创意与管理学院-网络与新媒体专业及地址